### PR TITLE
Updated README.md and AndroidManifest.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,5 +141,8 @@ Done!  You should now have the app running on your USB debugging connected table
 ### Working with eclipse
 If you would like to use eclipse, then type "eclipse" at the sbt prompt to autogenerate the project files.  Then go into eclipse and import all of the project directories in this tree.
 
-
+### Making Google Maps work
+To enable Google Maps after compiling you'll need to generate a new key and replace that key in the manifest.
+Please follow [Installing The Google Maps Android V2 API](https://developers.google.com/maps/documentation/android/start#installing_the_google_maps_android_v2_api)
+The default location of the auto generated debug.keystore is at ```SDK_LOCATION/.android/debug.keystore```
 

--- a/andropilot/src/main/AndroidManifest.xml
+++ b/andropilot/src/main/AndroidManifest.xml
@@ -11,10 +11,9 @@
         android:normalScreens="true"
         android:smallScreens="true" />
 
-    <uses-permission android:name="android.permission.INTERNET" >
-    </uses-permission>
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" >
-    </uses-permission>
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     
     <uses-permission android:name="android.permission.BLUETOOTH" />


### PR DESCRIPTION
Added ACCESS_NETWORK_STATE permission to avoid Google Maps correct behavior under poor connectivity conditions.
**Error seen on logcat:**
`Failed to connect to Google Maps Server. Please add <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/> into AndroidManifest.xml to ensure correct behavior under poor connectivity conditions.`
